### PR TITLE
Updated to fix query for non-WaterTemp datasets

### DIFF
--- a/services/Models/Dataset.cs
+++ b/services/Models/Dataset.cs
@@ -77,7 +77,18 @@ namespace services.Models
 
             //add on any "system" fields we want to also return
             var activity_fields = "ActivityDate,";
-            var system_fields = "CreateDate,QAStatusId,QAStatusName, ActivityQAComments, LocationId,ActivityQAStatusId,DatasetId,ActivityId,RowId, RowStatusId";
+
+            var system_fields = "";
+            if (this.Datastore.TablePrefix == "WaterTemp")
+            {
+                logger.Debug("This dataset is WaterTemp related...");
+                system_fields = "CreateDate,QAStatusId,QAStatusName, ActivityQAComments, LocationId,ActivityQAStatusId,DatasetId,ActivityId,RowId, RowStatusId";
+            }
+            else
+            {
+                logger.Debug("This dataset IS NOT WaterTemp related...");
+                system_fields = "CreateDate,QAStatusName, ActivityQAComments, LocationId,ActivityQAStatusId,DatasetId,ActivityId,RowId, RowStatusId";
+            }
 
             return activity_fields + header_fields + detail_fields + system_fields;
         }

--- a/services/Models/Project.cs
+++ b/services/Models/Project.cs
@@ -13,7 +13,7 @@ namespace services.Models
 
         private const int SUPERUSER_KEN = 1;
         private const int SUPERUSER_COLETTE = 2;
-        private const int SUPERUSER_GEORGE = 1082;
+        private const int SUPERUSER_GEORGE = 1081;
         private const int SUPERUSER_STACY = 9;
 
         public int Id { get; set; }


### PR DESCRIPTION
We had problems running the query on the WaterQuality dataset.  The dataset does not have a row-level QA (QAStatusId).  This fix removes the field from the select statement for all non-WaterTemp-related datasets.
